### PR TITLE
Add plannedMaintenance to StatusioV1Status

### DIFF
--- a/stts/Services/Super/StatusioV1Service.swift
+++ b/stts/Services/Super/StatusioV1Service.swift
@@ -14,6 +14,7 @@ protocol RequiredStatusioV1Properties {
 class BaseStatusioV1Service: BaseService {
     private enum StatusioV1Status: Int {
         case operational = 100
+        case plannedMaintenance = 200
         case degradedPerformance = 300
         case partialServiceDisruption = 400
         case serviceDisruption = 500
@@ -23,6 +24,8 @@ class BaseStatusioV1Service: BaseService {
             switch self {
             case .operational:
                 return .good
+            case .plannedMaintenance:
+                return .maintenance
             case .degradedPerformance:
                 return .minor
             case .partialServiceDisruption:


### PR DESCRIPTION
"Planned Maintenance" in status.io v1 are currently shown as "Unexpected Data".

<details><summary>example payload (via https://api.status.io/1.0/status/55957a99e800baa4470002da)</summary>
<pre>
{
  "result": {
    "status_overall": {
      "updated": "2021-02-26T19:28:28.835Z",
      "status": "Planned Maintenance",
      "status_code": 200
    },
    "status": [
      {
        "id": "55f73868aca7c180400010f7",
        "name": "acme-v01.api.letsencrypt.org (Production)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Planned Maintenance",
        "status_code": 200,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-25T19:27:25.652Z",
            "status": "Planned Maintenance",
            "status_code": 200
          },
          {
            "id": "55957b1c0b10966b48000309",
            "name": "High Assurance Datacenter 2",
            "updated": "2021-02-25T19:27:25.655Z",
            "status": "Planned Maintenance",
            "status_code": 200
          }
        ]
      },
      {
        "id": "5aa8056d14d0a40560057874",
        "name": "acme-v02.api.letsencrypt.org (Production)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-25T19:26:26.618Z",
            "status": "Operational",
            "status_code": 100
          },
          {
            "id": "55957b1c0b10966b48000309",
            "name": "High Assurance Datacenter 2",
            "updated": "2021-02-25T19:26:26.631Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "55f87415b6dca5de43001181",
        "name": "ocsp.root-x1.letsencrypt.org",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-19T20:04:02.631Z",
            "status": "Operational",
            "status_code": 100
          },
          {
            "id": "55957b1c0b10966b48000309",
            "name": "High Assurance Datacenter 2",
            "updated": "2021-02-19T20:04:02.669Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "56f494de215a208e1c00002b",
        "name": "{e1,e2,r3,r4}.o.lencr.org & ocsp.int-x{3..4}.letsencrypt.org",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-19T20:04:02.632Z",
            "status": "Operational",
            "status_code": 100
          },
          {
            "id": "55957b1c0b10966b48000309",
            "name": "High Assurance Datacenter 2",
            "updated": "2021-02-19T20:04:02.667Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "55957a99e800baa4470002ea",
        "name": "Website",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957b4f0b10966b4800030a",
            "name": "Public Data Center",
            "updated": "2020-08-30T16:19:42.648Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "559abab7e800baa44700079e",
        "name": "acme-staging.api.letsencrypt.org (Staging)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Planned Maintenance",
        "status_code": 200,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-25T19:27:25.654Z",
            "status": "Planned Maintenance",
            "status_code": 200
          }
        ]
      },
      {
        "id": "5a4fb3b724542523a2d704cc",
        "name": "acme-staging-v02.api.letsencrypt.org (Staging)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-23T02:15:57.901Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "55963e20abc4f73d4b000332",
        "name": "ocsp.staging-x1.letsencrypt.org (Staging)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957a99e800baa4470002e9",
            "name": "High Assurance Datacenter 1",
            "updated": "2021-02-14T02:47:57.706Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "5cdbf34c8d3a2f4aa388dd8d",
        "name": "oak.ct.letsencrypt.org (Production)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957b4f0b10966b4800030a",
            "name": "Public Data Center",
            "updated": "2020-08-30T16:19:42.654Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      },
      {
        "id": "5cdbf33b75b6624afc04ea9d",
        "name": "testflume.ct.letsencrypt.org (Testing)",
        "updated": "2021-02-26T19:28:28.835Z",
        "status": "Operational",
        "status_code": 100,
        "containers": [
          {
            "id": "55957b4f0b10966b4800030a",
            "name": "Public Data Center",
            "updated": "2020-08-30T16:19:42.648Z",
            "status": "Operational",
            "status_code": 100
          }
        ]
      }
    ],
    "incidents": [],
    "maintenance": {
      "active": [
        {
          "name": "ACMEv1 Brownout - Staging & Production ",
          "_id": "600a8afeddef08053a253e72",
          "datetime_open": "2021-01-22T08:21:18.284Z",
          "datetime_planned_start": "2021-02-25T17:00:00.000Z",
          "datetime_planned_end": "2021-02-26T17:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Staging and Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 24 hours. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T08:21:18.306Z"
            },
            {
              "details": "We have disabled the ACMEv1 API in Staging and Production in line with our ACMEv1 deprecation plans. This brownout will last approximately 24 hours. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 200,
              "status": 200,
              "datetime": "2021-02-25T19:27:25.602Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            },
            {
              "name": "acme-staging.api.letsencrypt.org (Staging)",
              "_id": "559abab7e800baa44700079e"
            }
          ]
        }
      ],
      "upcoming": [
        {
          "name": "ACMEv1 Brownout - Production ",
          "_id": "600b2fb51558dc05445bc5bd",
          "datetime_open": "2021-01-22T20:04:05.787Z",
          "datetime_planned_start": "2021-05-18T18:00:00.000Z",
          "datetime_planned_end": "2021-05-25T18:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 7days. This is the final brownout before ACMEv1 is fully deprecated. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T20:04:05.819Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            }
          ]
        },
        {
          "name": "ACMEv1 Brownout - Production",
          "_id": "600b2ed6a9c1290530967e5f",
          "datetime_open": "2021-01-22T20:00:22.890Z",
          "datetime_planned_start": "2021-05-06T18:00:00.000Z",
          "datetime_planned_end": "2021-05-11T18:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 5 days. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T20:00:22.906Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            }
          ]
        },
        {
          "name": "ACMEv1 Brownout - Production ",
          "_id": "600b2e6bddef08053a253ebd",
          "datetime_open": "2021-01-22T19:58:35.914Z",
          "datetime_planned_start": "2021-04-23T18:00:00.000Z",
          "datetime_planned_end": "2021-04-26T18:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 72 hours. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T19:58:35.954Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            }
          ]
        },
        {
          "name": "ACMEv1 Brownout - Production",
          "_id": "600b2e0b78ae73053702fd4d",
          "datetime_open": "2021-01-22T19:56:59.990Z",
          "datetime_planned_start": "2021-04-06T18:00:00.000Z",
          "datetime_planned_end": "2021-04-09T18:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 72 hours. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T19:57:00.028Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            }
          ]
        },
        {
          "name": "ACMEv1 Brownout - Staging & Production",
          "_id": "600b28caa9c1290530967e5a",
          "datetime_open": "2021-01-22T19:34:34.964Z",
          "datetime_planned_start": "2021-03-24T18:00:00.000Z",
          "datetime_planned_end": "2021-03-26T18:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Staging and Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 48 hours. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T19:34:35.008Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            },
            {
              "name": "acme-staging.api.letsencrypt.org (Staging)",
              "_id": "559abab7e800baa44700079e"
            }
          ]
        },
        {
          "name": "ACMEv1 Brownout - Staging & Production ",
          "_id": "600b286fd5d94905355d8058",
          "datetime_open": "2021-01-22T19:33:03.834Z",
          "datetime_planned_start": "2021-03-15T18:00:00.000Z",
          "datetime_planned_end": "2021-03-17T18:00:00.000Z",
          "messages": [
            {
              "details": "We will disable the ACMEv1 API in Staging and Production in line with our ACMEv1 deprecation plans. This brownout will last aproximately 48 hours. More information available here https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/16",
              "state": 100,
              "status": 200,
              "datetime": "2021-01-22T19:33:03.856Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            },
            {
              "name": "High Assurance Datacenter 2",
              "_id": "55957b1c0b10966b48000309"
            }
          ],
          "components_affected": [
            {
              "name": "acme-v01.api.letsencrypt.org (Production)",
              "_id": "55f73868aca7c180400010f7"
            },
            {
              "name": "acme-staging.api.letsencrypt.org (Staging)",
              "_id": "559abab7e800baa44700079e"
            }
          ]
        },
        {
          "name": "Staging maintenance and database reset",
          "_id": "60348e5229fa5405b3adab97",
          "datetime_open": "2021-02-23T05:10:42.998Z",
          "datetime_planned_start": "2021-03-02T16:30:00.000Z",
          "datetime_planned_end": "2021-03-02T18:30:00.000Z",
          "messages": [
            {
              "details": "We’re clearing certificate and order data in our Staging Environment as part of a larger database modernization project. We will not be clearing account data, so clients will not need to re-register, and rate-limit exceptions for staging will continue to work as planned.\r\n\r\nPlease see the community forum topic for more details:\r\nhttps://community.letsencrypt.org/t/staging-maintenance-and-database-reset-2-march-2021/145957/2",
              "state": 100,
              "status": 200,
              "datetime": "2021-02-23T05:10:43.016Z"
            }
          ],
          "containers_affected": [
            {
              "name": "High Assurance Datacenter 1",
              "_id": "55957a99e800baa4470002e9"
            }
          ],
          "components_affected": [
            {
              "name": "acme-staging.api.letsencrypt.org (Staging)",
              "_id": "559abab7e800baa44700079e"
            },
            {
              "name": "acme-staging-v02.api.letsencrypt.org (Staging)",
              "_id": "5a4fb3b724542523a2d704cc"
            },
            {
              "name": "ocsp.staging-x1.letsencrypt.org (Staging)",
              "_id": "55963e20abc4f73d4b000332"
            }
          ]
        }
      ]
    }
  }
}
</pre>
</details>

Actual Behavior
--

<img width="288" src="https://user-images.githubusercontent.com/20679825/109364381-9541cb80-7886-11eb-9715-85076588a874.png">

Expected Behavior
--

<img width="288" src="https://user-images.githubusercontent.com/20679825/109364384-983cbc00-7886-11eb-9865-8b6921e47c8a.png">
