### PR TITLE
Compact list view preference (hide good status)

### DIFF
--- a/stts/EditorTableView/EditorTableViewController.swift
+++ b/stts/EditorTableView/EditorTableViewController.swift
@@ -154,7 +154,7 @@ class EditorTableViewController: NSObject, SwitchableTableViewController {
             settingsView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             settingsView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             settingsView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            settingsView.heightAnchor.constraint(equalToConstant: 130)
+            settingsView.heightAnchor.constraint(equalToConstant: 150)
         ])
     }
 

--- a/stts/EditorTableView/SettingsView.swift
+++ b/stts/EditorTableView/SettingsView.swift
@@ -10,6 +10,7 @@ class SettingsView: NSView {
     let settingsHeader = SectionHeaderView(name: "Preferences")
     let startAtLoginCheckbox = NSButton()
     let notifyCheckbox = NSButton()
+    let hideGoodStatus = NSButton()
 
     let servicesHeader = SectionHeaderView(name: "Services")
     let searchField = NSSearchField()
@@ -27,7 +28,7 @@ class SettingsView: NSView {
     }
 
     func setup() {
-        [settingsHeader, startAtLoginCheckbox, notifyCheckbox, servicesHeader, searchField].forEach {
+        [settingsHeader, startAtLoginCheckbox, notifyCheckbox, hideGoodStatus, servicesHeader, searchField].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             addSubview($0)
         }
@@ -47,6 +48,13 @@ class SettingsView: NSView {
         notifyCheckbox.state = Preferences.shared.notifyOnStatusChange ? .on : .off
         notifyCheckbox.action = #selector(SettingsView.updateNotifyOnStatusChange)
         notifyCheckbox.target = self
+
+        hideGoodStatus.setButtonType(.switch)
+        hideGoodStatus.title = "Hide good status description"
+        hideGoodStatus.font = smallFont
+        hideGoodStatus.state = Preferences.shared.hideGoodStatusMessage ? .on : .off
+        hideGoodStatus.action = #selector(SettingsView.hideGoodStatusMessage)
+        hideGoodStatus.target = self
 
         searchField.sendsSearchStringImmediately = true
         searchField.sendsWholeSearchString = false
@@ -69,7 +77,12 @@ class SettingsView: NSView {
             notifyCheckbox.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
             notifyCheckbox.heightAnchor.constraint(equalToConstant: 18),
 
-            servicesHeader.topAnchor.constraint(equalTo: notifyCheckbox.bottomAnchor, constant: 10),
+            hideGoodStatus.topAnchor.constraint(equalTo: notifyCheckbox.bottomAnchor, constant: 6),
+            hideGoodStatus.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            hideGoodStatus.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            hideGoodStatus.heightAnchor.constraint(equalToConstant: 18),
+
+            servicesHeader.topAnchor.constraint(equalTo: hideGoodStatus.bottomAnchor, constant: 10),
             servicesHeader.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
             servicesHeader.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
             servicesHeader.heightAnchor.constraint(equalToConstant: 16),
@@ -87,6 +100,10 @@ class SettingsView: NSView {
 
     @objc private func updateNotifyOnStatusChange() {
         Preferences.shared.notifyOnStatusChange = (notifyCheckbox.state == .on)
+    }
+
+    @objc private func hideGoodStatusMessage() {
+        Preferences.shared.hideGoodStatusMessage = (hideGoodStatus.state == .on)
     }
 
     @objc private func filterServices() {

--- a/stts/Preferences.swift
+++ b/stts/Preferences.swift
@@ -13,6 +13,11 @@ struct Preferences {
         set { UserDefaults.standard.set(newValue, forKey: "notifyOnStatusChange") }
     }
 
+    var hideGoodStatusMessage: Bool {
+        get { return UserDefaults.standard.bool(forKey: "hideGoodStatusMessage") }
+        set { UserDefaults.standard.set(newValue, forKey: "hideGoodStatusMessage") }
+    }
+
     var selectedServices: [BaseService] {
         get {
             guard let classNames = UserDefaults.standard.array(forKey: "selectedServices") as? [String] else {
@@ -31,6 +36,7 @@ struct Preferences {
     init() {
         UserDefaults.standard.register(defaults: [
             "notifyOnStatusChange": true,
+            "hideGoodStatusMessage": false,
             "selectedServices": ["CircleCI", "Cloudflare", "GitHub", "NPM", "TravisCI"]
         ])
 

--- a/stts/ServiceTableView/ServiceTableViewController.swift
+++ b/stts/ServiceTableView/ServiceTableViewController.swift
@@ -51,6 +51,7 @@ class ServiceTableViewController: NSObject, SwitchableTableViewController {
         }
 
         bottomBar.closeSettingsCallback = { [weak self] in
+            self?.reloadData()
             self?.editorTableViewController.hide()
             self?.show()
         }

--- a/stts/ServiceTableView/StatusTableCell.swift
+++ b/stts/ServiceTableView/StatusTableCell.swift
@@ -12,6 +12,8 @@ class StatusTableCell: NSTableCellView {
     let titleField = NSTextField()
     let statusField = NSTextField()
 
+    var hideGoodStatus = false
+
     enum Layout {
         static let verticalPadding: CGFloat = 10
         static let verticalSpacing: CGFloat = 4
@@ -112,7 +114,8 @@ class StatusTableCell: NSTableCellView {
 
     func setup(with service: Service) {
         titleField.stringValue = service.name
-        statusField.stringValue = service.message
         statusIndicator.status = service.status
+        statusField.stringValue = service.message
+        statusField.isHidden = service.status == .good && Preferences.shared.hideGoodStatusMessage
     }
 }


### PR DESCRIPTION
## Compact Status View

- added compact representation for services in good status (useful for a huge list of services, as of my case)
- can switch between representations
- ⚠️ in case service status _is not good_ the additional message still be displayed!
- 🙏 please help me with a better title for the option

And yeah, thanks for this amazing lil buddy in the tray :) ❤️ 


| Compact | Classic |
| ------ | ----- |
| <img width="328" alt="compact" src="https://user-images.githubusercontent.com/79844747/151619053-2af1d00c-9b17-4c7f-a305-80dc27df604b.png"> | <img width="328" alt="classic" src="https://user-images.githubusercontent.com/79844747/151619467-62bcf929-7b02-43d8-8a57-c9d70c19b906.png"> |

### added preferences

<img width="328" alt="preferences" src="https://user-images.githubusercontent.com/79844747/151619227-4955e156-1bc1-4a48-b34c-a87a17c228db.png">

