### PR TITLE
fix for Apple Services Parser

### DIFF
--- a/stts.xcodeproj/project.pbxproj
+++ b/stts.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		7B305FAB210237AA0086DCE0 /* Spoke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B305FAA210237AA0086DCE0 /* Spoke.swift */; };
 		7BA6A0A22240D8E000700C2C /* Bolt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6A0A12240D8E000700C2C /* Bolt.swift */; };
 		7E1580ED5174442F7B691728 /* Blend.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B31666FF70588A709098 /* Blend.swift */; };
+		91B0A21428197857007D8E8F /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B0A21328197857007D8E8F /* StringExtensionsTests.swift */; };
 		A071B75709D9B1CD27CB9A34 /* MongoDBCloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF59C4AA2A53663EAE8DA39 /* MongoDBCloud.swift */; };
 		A0C3F34B220FD630005D9998 /* Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C3F34A220FD630005D9998 /* Datadog.swift */; };
 		A125C59E20F7909500C513B3 /* Fastly.swift in Sources */ = {isa = PBXBuildFile; fileRef = A125C59D20F7909500C513B3 /* Fastly.swift */; };
@@ -342,6 +343,7 @@
 		87DE85B45D490EF40F319860 /* HashiCorp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HashiCorp.swift; sourceTree = "<group>"; };
 		881BD2B4F6BC008A1CE1A25B /* HelloSignHelloFax.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HelloSignHelloFax.swift; sourceTree = "<group>"; };
 		8FD39EC5F0FC240DE74BD82D /* LinkedInAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LinkedInAPI.swift; sourceTree = "<group>"; };
+		91B0A21328197857007D8E8F /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		9C6AF196D47310053DE2A8A0 /* Cypress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cypress.swift; sourceTree = "<group>"; };
 		9FD90A7C5F03EDEEB92424A2 /* Checkly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Checkly.swift; sourceTree = "<group>"; };
 		A0C3F34A220FD630005D9998 /* Datadog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Datadog.swift; sourceTree = "<group>"; };
@@ -647,6 +649,7 @@
 				B2563BC122CBC92400532C39 /* Mocks */,
 				B2163AF920BA4E7500B14A85 /* Info.plist */,
 				B2163AF720BA4E7500B14A85 /* sttsTests.swift */,
+				91B0A21328197857007D8E8F /* StringExtensionsTests.swift */,
 			);
 			path = sttsTests;
 			sourceTree = "<group>";
@@ -1260,6 +1263,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91B0A21428197857007D8E8F /* StringExtensionsTests.swift in Sources */,
 				B2563BBE22CBC65A00532C39 /* URLSessionMock.swift in Sources */,
 				B2163AF820BA4E7500B14A85 /* sttsTests.swift in Sources */,
 			);

--- a/stts/Extensions/StringExtensions.swift
+++ b/stts/Extensions/StringExtensions.swift
@@ -7,8 +7,10 @@ import Cocoa
 
 extension String {
     var innerJSONString: String {
+        /// at some point Apple started sending new line at the end of json callback wrapper
+        /// therefore, we probe end of string, to assign callbackSuffix accordingly
         let callbackPrefix = "jsonCallback("
-        let callbackSuffix = ");"
+        let callbackSuffix = hasSuffix("\n") ? ");\n" : ");"
 
         guard hasPrefix(callbackPrefix) && hasSuffix(callbackSuffix) else { return self }
 

--- a/sttsTests/StringExtensionsTests.swift
+++ b/sttsTests/StringExtensionsTests.swift
@@ -1,0 +1,25 @@
+//
+//  StringExtensionsTests.swift
+//  sttsTests
+//
+
+import XCTest
+@testable import stts
+
+class StringExtensionsTests: XCTestCase {
+
+    func testInnerJsonStringWithNewLine() throws {
+        let jsonCallback = "jsonCallback(✅);\n"
+        XCTAssertEqual(jsonCallback.innerJSONString, "✅")
+    }
+
+    func testInnerJsonStringWithoutNewLine() throws {
+        let jsonCallback = "jsonCallback(✅);"
+        XCTAssertEqual(jsonCallback.innerJSONString, "✅")
+    }
+
+    func testInnerJsonStringOther() throws {
+        let jsonCallback = "out of scope"
+        XCTAssertEqual(jsonCallback.innerJSONString, "out of scope")
+    }
+}


### PR DESCRIPTION
At some point Apple started sending new line at the end of json callback wrapper, turning the implementation of `innerJSONString` to fail. This PR fixes that, leaving the flexibility to Apple to add or remove `\n` at the end of the wrapper :) 
