### PR TITLE
Add a StatusPageService for Netskope Trust Portal

### DIFF
--- a/stts.xcodeproj/project.pbxproj
+++ b/stts.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		7B305FAB210237AA0086DCE0 /* Spoke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B305FAA210237AA0086DCE0 /* Spoke.swift */; };
 		7BA6A0A22240D8E000700C2C /* Bolt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6A0A12240D8E000700C2C /* Bolt.swift */; };
 		7E1580ED5174442F7B691728 /* Blend.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B31666FF70588A709098 /* Blend.swift */; };
+		7E729FE2526A0074B32685C4 /* NetskopeTrustPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B0258BF6AA353F9AC12443 /* NetskopeTrustPortal.swift */; };
 		7F96823683B97EF8AEA15F62 /* EquinixMetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF74DC57A426C3EBFCC2E90 /* EquinixMetal.swift */; };
 		885398879BE642F02CBA18BB /* QuickBooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FE9B86802DA92D1851DA069 /* QuickBooks.swift */; };
 		91B0A21428197857007D8E8F /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B0A21328197857007D8E8F /* StringExtensionsTests.swift */; };
@@ -370,6 +371,7 @@
 		53F844F11070AF5B4CD7719E /* Workflowy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Workflowy.swift; sourceTree = "<group>"; };
 		563FBDC323AC595F540679B9 /* Cybersource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cybersource.swift; sourceTree = "<group>"; };
 		599C548E19B1B95EFDBB7898 /* VMwareCarbonBlack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMwareCarbonBlack.swift; sourceTree = "<group>"; };
+		66B0258BF6AA353F9AC12443 /* NetskopeTrustPortal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetskopeTrustPortal.swift; sourceTree = "<group>"; };
 		6B24BCA673F692E9211E7B8D /* Medium.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Medium.swift; sourceTree = "<group>"; };
 		6BCBA0E92558643D0019DF23 /* Recruiterbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recruiterbox.swift; sourceTree = "<group>"; };
 		70244989EDA4E2F3CF20FA50 /* Doppler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Doppler.swift; sourceTree = "<group>"; };
@@ -942,6 +944,7 @@
 				B299C8461DD04D7C0024D2E9 /* NPM.swift */,
 				F679F245A03F4CCC7F2DA71F /* NasdaqDataLink.swift */,
 				D819CB63B6576DA05BFC764C /* Netlify.swift */,
+				66B0258BF6AA353F9AC12443 /* NetskopeTrustPortal.swift */,
 				B299C8421DD044160024D2E9 /* NewRelic.swift */,
 				B2107BCD254C970000284EE7 /* Notion.swift */,
 				B22BB3A0223B341B00B43BED /* OnePassword.swift */,
@@ -1676,6 +1679,7 @@
 				D6FC1C0B5C45F3865F9D6543 /* Smarty.swift in Sources */,
 				C6B979E923630AC2F73717B0 /* Cybersource.swift in Sources */,
 				3DD3827D39BBDDBDA24DA4B9 /* Roadmunk.swift in Sources */,
+				7E729FE2526A0074B32685C4 /* NetskopeTrustPortal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/stts/Services/StatusPage/NetskopeTrustPortal.swift
+++ b/stts/Services/StatusPage/NetskopeTrustPortal.swift
@@ -1,0 +1,12 @@
+//
+//  NetskopeTrustPortal.swift
+//  stts
+//
+
+import Foundation
+
+class NetskopeTrustPortal: StatusPageService {
+    let name = "Netskope Trust Portal"
+    let url = URL(string: "https://trust.netskope.com")!
+    let statusPageID = "l0zqmx0dg2zs"
+}


### PR DESCRIPTION
This PR adds a `StatusPageService` for Netskope Trust Portal, a service health status page for [Netskope](https://www.netskope.com/)'s various datacenters and various cloud security gateway services.

The file modifications were generated by the following command and the metadata of the status site.

```ruby
bundle exec ruby extract.rb https://trust.netskope.com
```

```json
{
  "page": {
    "id": "l0zqmx0dg2zs",
    "name": "Netskope Trust Portal",
    "url": "https://trust.netskope.com",
    "time_zone": "Etc/UTC",
    "updated_at": "2023-02-20T05:46:36.577Z"
  },
  "status": {
    "indicator": "none",
    "description": "All Systems Operational"
  }
}
```

Netskope Trust Portal is a service health site powered by Atlassian Statuspage as we can see at the right corner of the page.

![image](https://user-images.githubusercontent.com/4973774/220031677-f8a186c6-8d26-40fe-b5e2-6f06249abf04.png)

https://trust.netskope.com/incidents/lkn5nlqd06bq

Unfortunately, Netskope has disabled the button to subscribe status updates on their service health status page, so it would be very helpful if `stts` could notify us status changes.
