### PR TITLE
Updated fastly URL

### DIFF
--- a/stts/Services/Fastly.swift
+++ b/stts/Services/Fastly.swift
@@ -7,7 +7,7 @@ import Foundation
 import Kanna
 
 class Fastly: Service {
-    let url = URL(string: "https://status.fastly.com")!
+    let url = URL(string: "https://www.fastlystatus.com")!
 
     private enum Status: String, CaseIterable {
         case normal


### PR DESCRIPTION
Sometimes my stts app is showing a SSL error for the Fastly status check. It happens intermittently. There is a redirect from the old URL to the new one. I think updating the URL to the new one will fix it so it doesn't have to redirect which resolve the SSL error.

Screenshot:
![Screenshot 2023-11-06 at 3 52 30 PM](https://github.com/inket/stts/assets/9219376/8155ff4b-0467-49b9-ab0a-afb98f08c3ff)
