### PR TITLE
proposal: grow the popup frame to embed more items if needed

### DIFF
--- a/stts.xcodeproj/project.pbxproj
+++ b/stts.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		776E8314B2F7910C11B36F6A /* Statuspage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166DB4CDA6EACD6BF7EC77B0 /* Statuspage.swift */; };
 		79A2CABEDD66272C3579EB95 /* Robin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3859428AAF182EC79C4ED3E /* Robin.swift */; };
 		7BA6A0A22240D8E000700C2C /* Bolt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6A0A12240D8E000700C2C /* Bolt.swift */; };
+		7C82768C2C8E3CA800C0E37B /* ScreenHeightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C82768B2C8E3BE300C0E37B /* ScreenHeightHelper.swift */; };
 		7E1580ED5174442F7B691728 /* Blend.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7B31666FF70588A709098 /* Blend.swift */; };
 		7E729FE2526A0074B32685C4 /* NetskopeTrustPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B0258BF6AA353F9AC12443 /* NetskopeTrustPortal.swift */; };
 		7F96823683B97EF8AEA15F62 /* EquinixMetal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF74DC57A426C3EBFCC2E90 /* EquinixMetal.swift */; };
@@ -412,6 +413,7 @@
 		71284C408241E2CE20F2330D /* Scaleway.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scaleway.swift; sourceTree = "<group>"; };
 		71CE5D41DDC4D721C254C004 /* Proton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Proton.swift; sourceTree = "<group>"; };
 		7BA6A0A12240D8E000700C2C /* Bolt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bolt.swift; sourceTree = "<group>"; };
+		7C82768B2C8E3BE300C0E37B /* ScreenHeightHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenHeightHelper.swift; sourceTree = "<group>"; };
 		80361FCB72F96FA6F753D7C1 /* Bugsnag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Bugsnag.swift; sourceTree = "<group>"; };
 		8797E2420F50AEF8E643093F /* AlertLogic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertLogic.swift; sourceTree = "<group>"; };
 		87DE85B45D490EF40F319860 /* HashiCorp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HashiCorp.swift; sourceTree = "<group>"; };
@@ -1184,6 +1186,7 @@
 				B2A9BFB31DC6E30F001BD4B7 /* Icons.swift */,
 				B24D19F51DD072840052E539 /* Preferences.swift */,
 				B225E3DF1E44830F008E1D3D /* SwitchableTableViewController.swift */,
+				7C82768B2C8E3BE300C0E37B /* ScreenHeightHelper.swift */,
 				B2CF3FBF1DF7DD2100B66491 /* stts.entitlements */,
 			);
 			path = stts;
@@ -1668,6 +1671,7 @@
 				B2E70FD822B069BA000BCAD2 /* GoogleCloudPlatformServices.swift in Sources */,
 				B276D7642C4134AB00974DB6 /* JSDelivr.swift in Sources */,
 				B2BA36191ED7B0F200051083 /* AuthorizeNet.swift in Sources */,
+				7C82768C2C8E3CA800C0E37B /* ScreenHeightHelper.swift in Sources */,
 				B2542502293591610093AC83 /* StatusHubService.swift in Sources */,
 				B27F66A62A3609E8008DAF33 /* AWSService.swift in Sources */,
 				B28285E12405E44100B11A08 /* Zoom.swift in Sources */,

--- a/stts/ScreenHeightHelper.swift
+++ b/stts/ScreenHeightHelper.swift
@@ -1,0 +1,33 @@
+//
+//  ScreenHeightHelper.swift
+//  stts
+//
+import Cocoa
+
+/// DisplaySizeHelper - checks in-flight active display size
+/// and offers proper height to the consumers
+class ScreenHeightHelper {
+    /// custom margin to be deducted from the computed screen rect (but not affecting defaultMaxHeight)
+    let verticalMargin: CGFloat
+    /// computed maximum available value for the given screen (please, use .update() when appropriate)
+    private(set) var currentMaxHeight: CGFloat
+    /// vertical margin used alway, initial max height used on init, and as long as NSScreen not available
+    init(verticalMargin: CGFloat, initialMaxHeight: CGFloat) {
+        self.verticalMargin = verticalMargin
+        self.currentMaxHeight = initialMaxHeight
+    }
+
+    /// updates max height by capturing current screen (where the mouse is)
+    func update() {
+        // Get the current mouse location in global coordinates and find screen containing it
+        let mouseLocation = NSEvent.mouseLocation
+        // yep, it can happen mac has no screen (just like it can have multiple screens)
+        let currentScreen = NSScreen.screens.first { $0.frame.contains(mouseLocation) }
+        // lastly, using .visibleFrame to respect Dock, and system status bar height (it's always horisontal)
+        if let rect = currentScreen?.visibleFrame {
+            let statusBarHeight = NSStatusBar.system.thickness
+            currentMaxHeight = rect.height - statusBarHeight - verticalMargin
+        }
+        // no sense to use else clause and set current to default, just keep what it was
+    }
+}

--- a/stts/ServiceTableView/ServiceTableViewController.swift
+++ b/stts/ServiceTableView/ServiceTableViewController.swift
@@ -12,6 +12,8 @@ class ServiceTableViewController: NSObject, SwitchableTableViewController {
     let tableView = NSTableView()
     let bottomBar = BottomBar()
     let addServicesNoticeField = NSTextField()
+    // margin needed to mitigate MBPopup's MBPopupBackgroundView 8px arrow and bounds
+    let sizeHelper = ScreenHeightHelper(verticalMargin: 32, initialMaxHeight: 490)
 
     var editorTableViewController: EditorTableViewController
 
@@ -146,6 +148,7 @@ class ServiceTableViewController: NSObject, SwitchableTableViewController {
     }
 
     func willOpenPopup() {
+        sizeHelper.update()
         resizeViews()
         reloadData()
 
@@ -178,7 +181,7 @@ class ServiceTableViewController: NSObject, SwitchableTableViewController {
 
     func resizeViews() {
         var frame = scrollView.frame
-        frame.size.height = min(tableView.intrinsicContentSize.height, 490)
+        frame.size.height = min(tableView.intrinsicContentSize.height, sizeHelper.currentMaxHeight)
         scrollView.frame = frame
 
         (NSApp.delegate as? AppDelegate)?.popupController.resizePopup(


### PR DESCRIPTION
## grow the panel down as long as possible (with respect to Dock)

proposal now only implemented in the Services Controller, and Settings screen stays 'as is' - and, to my best idea, it could also benefit from a bit of vertical space.

![longlongfloat](https://github.com/user-attachments/assets/07380518-e908-4566-ab2d-1542e6b6988e)


