### PR TITLE
Restore entitlements to submit to App Store

### DIFF
--- a/stts/stts.entitlements
+++ b/stts/stts.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
The entitlements file is used by the build phase script to sign StartAtLoginHelper and enable sandboxing