### PR TITLE
Add Depot Service and support for IncidentIO inside the extract.rb script

### DIFF
--- a/Resources/services.json
+++ b/Resources/services.json
@@ -66,6 +66,10 @@
       ]
     },
     {
+      "name": "Depot",
+      "url": "https://status.depot.dev"
+    },
+    {
       "name": "HashiCorp",
       "url": "https://status.hashicorp.com"
     },

--- a/Resources/services.json
+++ b/Resources/services.json
@@ -38,7 +38,7 @@
     {
       "name": "Runway",
       "url": "https://status.runway.team"
-    },
+    }
   ],
   "cstate": [
     {

--- a/extract.rb
+++ b/extract.rb
@@ -51,6 +51,44 @@ class #{safe_name}: InstatusService {
     return true
 end
 
+def extract_incidentio(url, source, custom_name)
+    # IncidentIO pages include an "incident.io" attribution link in the footer
+    return false unless source.include?("incident.io")
+
+    base_url = url.chomp("/")
+    api_source = source_for("#{base_url}/api/v2/summary.json")
+    return false unless api_source
+
+    page = JSON.parse(api_source)["page"]
+    return false unless page
+
+    name = custom_name || page["name"]
+
+    services_path = "Resources/services.json"
+    services = JSON.parse(File.read(services_path))
+    
+    services["incidentio"] ||= []
+    
+    # Check if a service with the same URL already exists
+    exists = services["incidentio"].any? { |s| s["url"] == base_url }
+    if exists
+        puts "Service already exists in services.json"
+        return true
+    end
+
+    services["incidentio"] << {
+        "name" => name,
+        "url" => base_url
+    }
+
+    services["incidentio"].sort_by! { |s| s["name"].downcase }
+
+    File.write(services_path, JSON.pretty_generate(services) + "\n")
+    puts "Updated #{services_path}"
+
+    true
+end
+
 def extract_statuspage(url, custom_name)
     source = source_for("#{url}/api/v2/summary.json")
     return false unless source
@@ -280,6 +318,7 @@ fail_network unless source
 
 finish if extract_instatus(source, custom_name)
 finish if extract_site24x7(url, source, custom_name)
+finish if extract_incidentio(url, source, custom_name)
 finish if extract_statuspage(url, custom_name)
 finish if extract_cstate(url, custom_name)
 


### PR DESCRIPTION
# Add IncidentIO extraction support and Depot service

## Description
This PR integrates support for automatically extracting and importing IncidentIO status pages using the newer JSON-based workflow. It also adds **Depot** to the list of tracked services.

### Changes made
* **Update `extract.rb`**: Adds the `extract_incidentio` extraction logic. It determines if a URL matches the IncidentIO footprint, fetches the API summary, and dynamically injects the service entry straight into `Resources/services.json`. It gracefully avoids duplicates and auto-sorts alphabetically by name.
* **Fix invalid JSON**: Removed a stray trailing comma in the `betteruptime` object map within `services.json`. This was actively preventing Ruby's strict `JSON.parse` from booting up and modifying the services list during the extraction phase.
* **Add Depot service**: Successfully pushed `https://status.depot.dev` to the IncidentIO providers list.

## Testing
- Verified `bundle exec ruby extract.rb https://status.depot.dev` flawlessly updates the JSON instead of generating a Swift wrapper target.

**Note:** I'm not a swift developer, so I couldn't test whether this new service (Depot) works, but I tested the `extract` script, and it works correctly.

@inket let me know what you think
